### PR TITLE
Update requirements for Python 3.5 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django==1.7.4
-django-debug-toolbar==1.2.2
+Django==1.9.6
+django-debug-toolbar==1.4


### PR DESCRIPTION
The version of Django pinned in `requirements.txt` (1.7.4) doesn't seem to work
with Python 3.5 due to changes in `html.parser` (see
http://www.thefourtheye.in/2015/02/python-35-and-django-17s-htmlparseerror.html).

The newest versions of Django and the debug toolbar fix the issue, and
it appears the app still functions as expected, although I admittedly
didn't do much testing (don't want to spoil the fun at OSCON).